### PR TITLE
fix: add compiler classpath to inputs in `scala_proto_library`

### DIFF
--- a/rules/scala_proto/private/core.bzl
+++ b/rules/scala_proto/private/core.bzl
@@ -29,6 +29,8 @@ def scala_proto_library_implementation(ctx):
 
     compiler_inputs, _, _ = ctx.resolve_command(tools = [compiler.compiler])
 
+    compiler_classpath = compiler.compiler[JavaInfo].transitive_runtime_jars
+
     srcjar = ctx.outputs.srcjar
 
     proto_path = ctx.actions.declare_directory("{}/proto_path".format(_safe_name(ctx.attr.name)))
@@ -57,7 +59,7 @@ def scala_proto_library_implementation(ctx):
 
     ctx.actions.run(
         mnemonic = "ScalaProtoCompile",
-        inputs = depset(direct = [], transitive = [transitive_sources, transitive_jars]),
+        inputs = depset(direct = [], transitive = [transitive_sources, transitive_jars, compiler_classpath]),
         outputs = [gendir, proto_path],
         executable = compiler.compiler.files_to_run.executable,
         tools = compiler_inputs,


### PR DESCRIPTION
Without this fix, worker dependencies were not explicitly declared, which caused an error when creating `scala_proto_library` if the worker was not built locally, e.g. when using a remote cache